### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ or using [unpkg](https://unpkg.com) CDN
 ```html
 <script src="https://unpkg.com/dush/dist/dush.umd.js"></script>
 ```
-
 > **Note:** Don't use Unpkg's short-hand endpoint `https://unpkg.com/dush`, 
 since it points to CommonJS bundle.
+
+or using [jsDelivr](https://www.jsdelivr.com/package/npm/dush) CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/dush/dist/dush.umd.js">
+```
 
 ## Usage
 


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) is the [fastest opensource cdn](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg. This PR adds it to the readme as an alternative to unpkg.